### PR TITLE
Removed comma

### DIFF
--- a/stores/BreadCrumb.js
+++ b/stores/BreadCrumb.js
@@ -239,7 +239,7 @@ define(["dojo/_base/array",
 			//		Menu item widget that was clicked
 			// evt:
 			//		Event object.
-		},
+		}
 
 	});
 	return CrumbTrail;


### PR DESCRIPTION
This caused an error in the dojo build tool, pretty minor:

0 error(s), 1 warning(s)
C:/Documents and Settings/Administrator/Desktop/build/release/cbtree/stores/BreadCrumb.js:246: ERROR - Parse error. Internet Explorer has a non-standard intepretation of trailing commas. Arrays will have the wrong length and objects will not parse at all.
    });
